### PR TITLE
gralloc: Fix RAW10/12 buffer alignment for trinket

### DIFF
--- a/gralloc/gr_utils.cpp
+++ b/gralloc/gr_utils.cpp
@@ -881,10 +881,10 @@ void GetAlignedWidthAndHeight(const BufferInfo &info, unsigned int *alignedw,
       aligned_w = ALIGN(width, 16);
       break;
     case HAL_PIXEL_FORMAT_RAW12:
-      aligned_w = ALIGN(width * 12 / 8, 16);
+      aligned_w = ALIGN(width * 12 / 8, 8);
       break;
     case HAL_PIXEL_FORMAT_RAW10:
-      aligned_w = ALIGN(width * 10 / 8, 16);
+      aligned_w = ALIGN(width * 10 / 8, 8);
       break;
     case HAL_PIXEL_FORMAT_RAW8:
       aligned_w = ALIGN(width, 16);


### PR DESCRIPTION
Change-Id: Ic543387f445f2238cb102219e5a89944a62c44fd